### PR TITLE
refactor: replace Phaser with Curves from import and use new Curves.Path() 

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Converts SVG `<path>` to `Phaser.Curves.Path` instance and returns it as `JSONPa
 
 ## Usage:
 ```js
+import { Curves } from 'phaser';
 import svgToPhaserPath from 'svg-to-phaser-path';
 
 const d = `M600,350 l 50,-25

--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ const d = `M600,350 l 50,-25
 
 const jsonPath = svgToPhaserPath(d);
 
-const path = new Phaser.Curves.Path(jsonPath);
+const path = new Curves.Path();
+path.fromJSON(jsonPath);
+
 ```
 
 ## Changelog

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-import Phaser from 'phaser';
+import { Curves } from 'phaser';
 import arcToBezier from 'svg-arc-to-cubic-bezier';
 import { parseSVG, makeAbsolute } from 'svg-path-parser';
 
@@ -12,7 +12,7 @@ const TWO_THIRDS = 2 / 3;
  * @return {Phaser.Types.Curves.JSONPath} `JSONPath` object that is the result of calling `toJSON()` method on the converted `Phaser.Curves.Path` instance.
  */
 function svgToPhaserPath(d, quadraticToCubic = false) {
-  const path = new Phaser.Curves.Path();
+  const path = new Curves.Path();
 
   const parsed = makeAbsolute(parseSVG(d));
 


### PR DESCRIPTION
## Summary
Replace Phaser import with Curves.

## Background

I'm using this library in my Phaser Games. I have several Phaser games on my home page. I don't want to load Phaser for each and every game, so I build the games with Vite, and exclude phaser from the build.

vite config example
```
rollupOptions: {
      // make sure to externalize deps that shouldn't be bundled
      // into your library
      external: ['phaser'],
      output: {
        globals: {
          phaser: 'Phaser',
        },
      },
    },
```
When we use `new Phaser.Curves.Path();`, Vite will import Phaser as 

`import Phaser$1 from "phaser";`, and I get an error message: 

> Error: export 'default' (imported as 'Phaser$1') was not found in 'phaser' 


Maybe I can alter the Vite config to avoid this error, but I found it easier to adjust how I use Phaser in my code, and also found that this module was doing the same thing as I did.
